### PR TITLE
Fix remote asset paths

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,14 +1,24 @@
 require 'securerandom'
 
 class RequestsController < ApplicationController
+  include ApplicationHelper
   include RequestsHelper
 
   # Show an individual request.
   def show
+    css_path = path_with_digest('application', 'css')
+    js_path = path_with_digest('application', 'js')
+
     find_request(params[:rid])
     respond_to do |format|
       format.html { render 'shared_request' }
-      format.js   { render :partial => 'requests/embed/embed' }
+      format.js   {
+        render :partial => 'requests/embed/embed',
+        :locals => {
+          :css_path => "#{site_url}/assets/#{css_path}",
+          :js_path => "#{site_url}/assets/#{js_path}"
+        }
+      }
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,8 @@ module ApplicationHelper
   # This helps keep a consistent look across all the site by setting a standard
   # format for the title elements.
   #
-  # Example:
+  # Examples
+  #
   #   No page name defined  => ReHTTP
   #   Page name defined     => Page name · ReHTTP
   #   Sub page name defined => Sub page · Parent · ReHTTP
@@ -34,5 +35,18 @@ module ApplicationHelper
     else
       return site_name
     end
+  end
+
+  # Construct the asset path with a digest attached.
+  #
+  # Examples
+  #
+  #   path_with_digest('application', 'css')
+  #   # => application-a6cebf5fe429bb0eda3f1b713c05499b.css
+  #
+  # Returns a string of the file with the digest hash.
+  def path_with_digest(filename, file_extension)
+    full_filepath = "#{filename}.#{file_extension}"
+    "#{filename}-#{Rails.application.assets.find_asset(full_filepath).digest}.#{file_extension}"
   end
 end

--- a/app/views/requests/embed/_embed.js.erb
+++ b/app/views/requests/embed/_embed.js.erb
@@ -1,3 +1,3 @@
-document.write('<link href="<%= site_url %>/assets/application.css" media="screen" rel="stylesheet" />');
+document.write('<link href="<%= css_path %>" media="screen" rel="stylesheet" />');
 document.write('<%= escape_javascript(render "requests/embed/embed_request") %>');
-document.write('<scr' + 'ipt src="<%= site_url %>/assets/application.js"></sc' + 'ript>');
+document.write('<scr' + 'ipt src="<%= js_path %>"></sc' + 'ript>');


### PR DESCRIPTION
The asset paths were not including the digest of the file which results in 404’s. Added in an application helper to resolve this.
